### PR TITLE
feat: deploy towonel-agent and home-operations/echo

### DIFF
--- a/kubernetes/apps/echo/flux-kustomization.yml
+++ b/kubernetes/apps/echo/flux-kustomization.yml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://chkpwd.github.io/iac/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app echo
+  namespace: &ns networking
+spec:
+  targetNamespace: *ns
+  path: ./kubernetes/apps/echo/
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: chkpwd-ops
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/echo/helm-release.yml
+++ b/kubernetes/apps/echo/helm-release.yml
@@ -1,0 +1,68 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/common-4.5.0/charts/library/common/values.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: echo
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: echo
+  values:
+    controllers:
+      echo:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        strategy: RollingUpdate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/home-operations/echo
+              tag: rolling
+            env:
+              TZ: "America/New_York"
+              ECHO_LOG_LEVEL: info
+              ECHO_TRUSTED_PROXIES: "10.0.0.0/8"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 8080
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+    route:
+      private:
+        kind: HTTPRoute
+        hostnames: ["echo.chkpwd.com"]
+        parentRefs:
+          - name: private
+            namespace: networking
+            sectionName: https

--- a/kubernetes/apps/echo/kustomization.yml
+++ b/kubernetes/apps/echo/kustomization.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helm-release.yml
+  - source.yml

--- a/kubernetes/apps/echo/source.yml
+++ b/kubernetes/apps/echo/source.yml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://chkpwd.github.io/iac/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: echo
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.1.3
+  url: oci://ghcr.io/home-operations/charts/echo

--- a/kubernetes/apps/kustomization.yml
+++ b/kubernetes/apps/kustomization.yml
@@ -27,6 +27,8 @@ resources:
   - autobrr/flux-kustomization.yml
   - trek/flux-kustomization.yml
   - suggestarr/flux-kustomization.yml
+  - echo/flux-kustomization.yml
+  - towonel-agent/flux-kustomization.yml
   # - sure/flux-kustomization.yml
   # - teslamateapi/flux-kustomization.yml
   # - dawarich/flux-kustomization.yml

--- a/kubernetes/apps/towonel-agent/external-secret.yml
+++ b/kubernetes/apps/towonel-agent/external-secret.yml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://chkpwd.github.io/iac/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: towonel-agent
+spec:
+  refreshInterval: 3h
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: towonel-agent-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: TOWONEL_INVITE_TOKEN
+      remoteRef:
+        key: towonel-tunnel
+        property: invite_token

--- a/kubernetes/apps/towonel-agent/flux-kustomization.yml
+++ b/kubernetes/apps/towonel-agent/flux-kustomization.yml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://chkpwd.github.io/iac/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app towonel-agent
+  namespace: &ns networking
+spec:
+  targetNamespace: *ns
+  path: ./kubernetes/apps/towonel-agent/
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets
+      namespace: flux-system
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: chkpwd-ops
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/towonel-agent/helm-release.yml
+++ b/kubernetes/apps/towonel-agent/helm-release.yml
@@ -19,6 +19,7 @@ spec:
       services:
         - hostname: echo.chkpwd.com
           origin: echo.networking.svc.cluster.local:8080
+          proxy_protocol: none
       inviteTokenSecret:
         name: towonel-agent-secret
         key: TOWONEL_INVITE_TOKEN

--- a/kubernetes/apps/towonel-agent/helm-release.yml
+++ b/kubernetes/apps/towonel-agent/helm-release.yml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://chkpwd.github.io/iac/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: towonel-agent
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: towonel-agent
+  values:
+    replicaCount: 2
+    deploymentAnnotations:
+      reloader.stakater.com/auto: "true"
+    agent:
+      logLevel: info
+      healthPort: 9090
+      services:
+        - hostname: echo.chkpwd.com
+          origin: echo.networking.svc.cluster.local:8080
+      inviteTokenSecret:
+        name: towonel-agent-secret
+        key: TOWONEL_INVITE_TOKEN
+    monitoring:
+      serviceMonitor:
+        enabled: true
+        interval: 1m
+      prometheusRule:
+        enabled: true
+      dashboards:
+        enabled: true
+        grafanaOperator:
+          enabled: true
+          allowCrossNamespaceImport: true
+          matchLabels:
+            grafana.internal/instance: grafana

--- a/kubernetes/apps/towonel-agent/kustomization.yml
+++ b/kubernetes/apps/towonel-agent/kustomization.yml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helm-release.yml
+  - source.yml
+  - external-secret.yml

--- a/kubernetes/apps/towonel-agent/source.yml
+++ b/kubernetes/apps/towonel-agent/source.yml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://chkpwd.github.io/iac/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: towonel-agent
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.1.27
+  url: oci://codeberg.org/towonel/charts/towonel-agent


### PR DESCRIPTION
Adds two new apps in the `networking` namespace:

- **echo** (`kubernetes/apps/echo/`) — HTTP request echo server from
  `home-operations/echo` (`oci://ghcr.io/home-operations/charts/echo`,
  tag `0.1.3`; image `ghcr.io/home-operations/echo:rolling`). Exposed
  internally as `echo.chkpwd.com` via the private HTTPRoute.

- **towonel-agent** (`kubernetes/apps/towonel-agent/`) — Tunnels
  external traffic in. Routes `echo.chkpwd.com` →
  `echo.networking.svc.cluster.local:8080`. Chart
  `oci://codeberg.org/towonel/charts/towonel-agent` tag `0.1.27`.

The towonel invite token is fetched from Bitwarden Secrets Manager
via a `towonel-tunnel` item with an `invite_token` field.

Both apps are registered in `kubernetes/apps/kustomization.yml`.